### PR TITLE
Introduce a LeadingTriviaRewriter that can retain leading trivia

### DIFF
--- a/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
+++ b/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Libraries.RoslynTripleSlash
+{
+    public static class LeadingTriviaRewriter
+    {
+        public static SyntaxNode ApplyXmlComments(SyntaxNode node, IEnumerable<SyntaxTrivia> xmlComments)
+        {
+            var leading = node.GetLeadingTrivia();
+            SyntaxTriviaList xmlTrivia = new();
+
+            if (leading.Any() && leading.Last().IsKind(SyntaxKind.WhitespaceTrivia))
+            {
+                SyntaxTrivia indentation = leading.Last();
+
+                foreach (var xmlComment in xmlComments)
+                {
+                    xmlTrivia = xmlTrivia.AddRange(new[] { indentation, xmlComment, SyntaxFactory.CarriageReturnLineFeed });
+                }
+
+                return node.ReplaceTrivia(indentation, xmlTrivia.Add(indentation));
+            }
+            foreach (var xmlComment in xmlComments)
+            {
+                xmlTrivia = xmlTrivia.AddRange(new[] { xmlComment, SyntaxFactory.CarriageReturnLineFeed });
+            }
+
+            return node.WithLeadingTrivia(leading.AddRange(xmlTrivia));
+        }
+    }
+}

--- a/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
+++ b/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
@@ -10,7 +10,7 @@ namespace Libraries.RoslynTripleSlash
 {
     public static class LeadingTriviaRewriter
     {
-        private static int[] UpperBoundaries = new[]
+        private static int[] TriviaAboveDocComments = new[]
         {
             (int)SyntaxKind.RegionDirectiveTrivia,
             (int)SyntaxKind.PragmaWarningDirectiveTrivia,
@@ -18,9 +18,10 @@ namespace Libraries.RoslynTripleSlash
             (int)SyntaxKind.EndIfDirectiveTrivia,
         };
 
-        public static int[] LowerBoundaries = new[]
+        public static int[] TriviaBelowDocComments = new[]
         {
-            (int)SyntaxKind.SingleLineCommentTrivia
+            (int)SyntaxKind.SingleLineCommentTrivia,
+            (int)SyntaxKind.MultiLineCommentTrivia
         };
 
         private static bool IsDocumentationCommentTrivia(this SyntaxTrivia trivia) =>
@@ -78,12 +79,12 @@ namespace Libraries.RoslynTripleSlash
                 // downward until we find the first node to stay above.
                 docsPosition = leading.Count;
 
-                while (docsPosition > 0 && !UpperBoundaries.Contains(leading[docsPosition.Value - 1].RawKind))
+                while (docsPosition > 0 && !TriviaAboveDocComments.Contains(leading[docsPosition.Value - 1].RawKind))
                 {
                     docsPosition--;
                 }
 
-                while (docsPosition < leading.Count - 1 && !LowerBoundaries.Contains(leading[docsPosition.Value].RawKind))
+                while (docsPosition < leading.Count && !TriviaBelowDocComments.Contains(leading[docsPosition.Value].RawKind))
                 {
                     docsPosition++;
                 }

--- a/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
+++ b/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
@@ -38,6 +38,20 @@ namespace Libraries.RoslynTripleSlash
             return trivia.WithoutDocumentationComments(out int? _);
         }
 
+        public static SyntaxTriviaList GetFinalWhitespace(this SyntaxTriviaList trivia)
+        {
+            SyntaxTriviaList indentation = new();
+            int index = trivia.Count;
+            
+            while (index > 0 && trivia[index - 1].IsKind(SyntaxKind.WhitespaceTrivia))
+            {
+                index--;
+                indentation = indentation.Insert(0, trivia[index]);
+            }
+
+            return indentation;
+        }
+
         public static SyntaxTriviaList WithoutDocumentationComments(this SyntaxTriviaList trivia, out int? existingDocsPosition)
         {
             int i = 0;
@@ -45,14 +59,7 @@ namespace Libraries.RoslynTripleSlash
 
             // Before we start removing the doc comments, we need to capture any whitespace at
             // the very end of the trivia, because it could represent indentation of the API.
-            SyntaxTriviaList indentation = new();
-            int indentationPosition = trivia.Count;
-
-            while (indentationPosition > 0 && trivia[indentationPosition - 1].IsKind(SyntaxKind.WhitespaceTrivia))
-            {
-                indentationPosition--;
-                indentation = indentation.Insert(0, trivia[indentationPosition]);
-            }
+            SyntaxTriviaList indentation = trivia.GetFinalWhitespace();
 
             while (i < trivia.Count)
             {
@@ -141,14 +148,7 @@ namespace Libraries.RoslynTripleSlash
             // pragmas or other trivia where the indentation might not match the API being
             // documented. Look at the end of the trivia (just before the API), and clone the
             // indentation for use in front of each line of documentation comments.
-            SyntaxTriviaList indentation = new();
-            int indentationPosition = leading.Count;
-
-            while (indentationPosition > 0 && leading[indentationPosition - 1].IsKind(SyntaxKind.WhitespaceTrivia))
-            {
-                indentationPosition--;
-                indentation = indentation.Insert(0, leading[indentationPosition]);
-            }
+            SyntaxTriviaList indentation = leading.GetFinalWhitespace();
 
             // Insert the XML comment lines with the collected indentation
             return node.WithLeadingTrivia(

--- a/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
+++ b/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
@@ -128,6 +128,13 @@ namespace Libraries.RoslynTripleSlash
                 {
                     docsPosition++;
                 }
+
+                // The last step is to walk backwards again through any whitespace
+                // to get back to the beginning of the line.
+                while (docsPosition > 0 && leading[docsPosition.Value - 1].IsKind(SyntaxKind.WhitespaceTrivia))
+                {
+                    docsPosition--;
+                }
             }
 
             // We know where the doc comments will be inserted, but they could go in adjacent to

--- a/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
+++ b/Libraries/RoslynTripleSlash/LeadingTriviaRewriter.cs
@@ -10,28 +10,56 @@ namespace Libraries.RoslynTripleSlash
 {
     public static class LeadingTriviaRewriter
     {
+        private static int[] UpperBoundaries = new[]
+        {
+            (int)SyntaxKind.RegionDirectiveTrivia
+        };
+
+        public static int[] LowerBoundaries = new[]
+        {
+            (int)SyntaxKind.IfDirectiveTrivia
+        };
+
         public static SyntaxNode ApplyXmlComments(SyntaxNode node, IEnumerable<SyntaxTrivia> xmlComments)
         {
-            var leading = node.GetLeadingTrivia();
+            SyntaxTriviaList leading = node.GetLeadingTrivia();
             SyntaxTriviaList xmlTrivia = new();
+            SyntaxTrivia indentation = SyntaxFactory.Whitespace("");
 
             if (leading.Any() && leading.Last().IsKind(SyntaxKind.WhitespaceTrivia))
             {
-                SyntaxTrivia indentation = leading.Last();
-
-                foreach (var xmlComment in xmlComments)
-                {
-                    xmlTrivia = xmlTrivia.AddRange(new[] { indentation, xmlComment, SyntaxFactory.CarriageReturnLineFeed });
-                }
-
-                return node.ReplaceTrivia(indentation, xmlTrivia.Add(indentation));
+                // If the last trivia before the declaration is whitespace
+                // then this represents indentation for the declaration
+                // and we'll match that indentation for the XML comments
+                indentation = leading.Last();
             }
+
+            // Create the indented XML comment lines
             foreach (var xmlComment in xmlComments)
             {
-                xmlTrivia = xmlTrivia.AddRange(new[] { xmlComment, SyntaxFactory.CarriageReturnLineFeed });
+                xmlTrivia = xmlTrivia.AddRange(new[] { indentation, xmlComment, SyntaxFactory.CarriageReturnLineFeed });
             }
 
-            return node.WithLeadingTrivia(leading.AddRange(xmlTrivia));
+            // We will determine the position at which to insert the XML
+            // comments. We want to find the spot closest to the declaration
+            // that makes sense, so we walk upward through the leading trivia
+            // until we find nodes we need to stay beneath. Then, we walk back
+            // downward until we find the first node to stay above.
+            int position = leading.Count;
+
+            while (position > 0 && !UpperBoundaries.Contains(leading[position - 1].RawKind))
+            {
+                position--;
+            }
+
+            while (position < leading.Count - 1 && !LowerBoundaries.Contains(leading[position].RawKind))
+            {
+                position++;
+            }
+
+            // Now that we know the position of where to insert our XML comments
+            // We replace that trivia with the XML trivia plus that trivia (to retain it)
+            return node.ReplaceTrivia(leading[position], xmlTrivia.Add(leading[position]));
         }
     }
 }

--- a/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
+++ b/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
@@ -1,0 +1,140 @@
+﻿#nullable enable
+using Libraries.RoslynTripleSlash;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Tests.PortToTripleSlash
+{
+    public class LeadingTriviaRewriterTests
+    {
+        public struct LeadingTriviaTestFile
+        {
+            public SyntaxNode MyType;
+            public SyntaxNode MyEnum;
+            public SyntaxNode MyField;
+            public SyntaxNode MyProperty;
+            public SyntaxNode MyMethod;
+        }
+
+        private static (LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) LoadTestFiles(string test)
+        {
+            Func<string, LeadingTriviaTestFile> LoadTestFile = (fileName) =>
+            {
+                string testFolder = "../../../PortToTripleSlash/TestData/LeadingTrivia";
+                string testContent = File.ReadAllText(Path.Combine(testFolder, fileName));
+
+                IEnumerable<SyntaxNode> nodes = SyntaxFactory.ParseSyntaxTree(testContent).GetRoot().DescendantNodes();
+
+                return new LeadingTriviaTestFile
+                {
+                    MyType = nodes.First(n => n.IsKind(SyntaxKind.ClassDeclaration)),
+                    MyEnum = nodes.First(n => n.IsKind(SyntaxKind.EnumDeclaration)),
+                    MyField = nodes.First(n => n.IsKind(SyntaxKind.FieldDeclaration)),
+                    MyProperty = nodes.First(n => n.IsKind(SyntaxKind.PropertyDeclaration)),
+                    MyMethod = nodes.First(n => n.IsKind(SyntaxKind.MethodDeclaration))
+                };
+            };
+
+            LeadingTriviaTestFile original = LoadTestFile($"{test}.Original.cs");
+            LeadingTriviaTestFile expected = LoadTestFile($"{test}.Expected.cs");
+
+            return (original, expected);
+        }
+
+        public static IEnumerable<object[]> GetLeadingTriviaTests()
+        {
+            yield return new object[] { LoadTestFiles("WhitespaceOnly") };
+        }
+
+        private static IEnumerable<SyntaxTrivia> GetTestComments()
+        {
+            XmlTextSyntax summaryText = SyntaxFactory.XmlText();
+            XmlElementSyntax summaryElement = SyntaxFactory.XmlSummaryElement(summaryText);
+            DocumentationCommentTriviaSyntax summaryComment = SyntaxFactory.DocumentationComment(summaryElement);
+            SyntaxTrivia summaryTrivia = SyntaxFactory.Trivia(summaryComment);
+
+            XmlTextSyntax remarksText = SyntaxFactory.XmlText();
+            XmlElementSyntax remarksElement = SyntaxFactory.XmlRemarksElement(remarksText);
+            DocumentationCommentTriviaSyntax remarksComment = SyntaxFactory.DocumentationComment(remarksElement);
+            SyntaxTrivia remarksTrivia = SyntaxFactory.Trivia(remarksComment);
+
+            return new SyntaxTrivia[] { summaryTrivia, remarksTrivia };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLeadingTriviaTests))]
+        public void AddsXmlToClassDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        {
+            var actual = LeadingTriviaRewriter.ApplyXmlComments(
+                test.Original.MyType,
+                GetTestComments()
+            ).GetLeadingTrivia().ToFullString();
+
+            var expected = test.Expected.MyType.GetLeadingTrivia().ToFullString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLeadingTriviaTests))]
+        public void AddsXmlToEnumDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        {
+            var actual = LeadingTriviaRewriter.ApplyXmlComments(
+                test.Original.MyEnum,
+                GetTestComments()
+            ).GetLeadingTrivia().ToFullString();
+
+            var expected = test.Expected.MyEnum.GetLeadingTrivia().ToFullString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLeadingTriviaTests))]
+        public void AddsXmlToFieldDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        {
+            var actual = LeadingTriviaRewriter.ApplyXmlComments(
+                test.Original.MyField,
+                GetTestComments()
+            ).GetLeadingTrivia().ToFullString();
+
+            var expected = test.Expected.MyField.GetLeadingTrivia().ToFullString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLeadingTriviaTests))]
+        public void AddsXmlToPropertyDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        {
+            var actual = LeadingTriviaRewriter.ApplyXmlComments(
+                test.Original.MyProperty,
+                GetTestComments()
+            ).GetLeadingTrivia().ToFullString();
+
+            var expected = test.Expected.MyProperty.GetLeadingTrivia().ToFullString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLeadingTriviaTests))]
+        public void AddsXmlToMethodDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        {
+            var actual = LeadingTriviaRewriter.ApplyXmlComments(
+                test.Original.MyMethod,
+                GetTestComments()
+            ).GetLeadingTrivia().ToFullString();
+
+            var expected = test.Expected.MyMethod.GetLeadingTrivia().ToFullString();
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
+++ b/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
@@ -51,8 +51,8 @@ namespace Tests.PortToTripleSlash
 
         public static IEnumerable<object[]> GetLeadingTriviaTests()
         {
-            //yield return new object[] { "WhitespaceOnly", LoadTestFiles("WhitespaceOnly") };
-            //yield return new object[] { "Directives", LoadTestFiles("Directives") };
+            yield return new object[] { "WhitespaceOnly", LoadTestFiles("WhitespaceOnly") };
+            yield return new object[] { "Directives", LoadTestFiles("Directives") };
             yield return new object[] { "ExistingXml", LoadTestFiles("ExistingXml") };
         }
 

--- a/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
+++ b/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
@@ -51,9 +51,10 @@ namespace Tests.PortToTripleSlash
 
         public static IEnumerable<object[]> GetLeadingTriviaTests()
         {
-            yield return new object[] { "WhitespaceOnly", LoadTestFiles("WhitespaceOnly") };
-            yield return new object[] { "Directives", LoadTestFiles("Directives") };
-            yield return new object[] { "ExistingXml", LoadTestFiles("ExistingXml") };
+            //yield return new object[] { "WhitespaceOnly", LoadTestFiles("WhitespaceOnly") };
+            //yield return new object[] { "Directives", LoadTestFiles("Directives") };
+            //yield return new object[] { "ExistingXml", LoadTestFiles("ExistingXml") };
+            yield return new object[] { "DirectivesExistingXml", LoadTestFiles("DirectivesExistingXml") };
         }
 
         private static IEnumerable<SyntaxTrivia> GetTestComments(string testName)
@@ -74,11 +75,12 @@ namespace Tests.PortToTripleSlash
         [Fact]
         public void WithoutDocumentationComments_RemovesSingleLineDocumentationComments()
         {
-            var trivia = SyntaxFactory.ParseLeadingTrivia(@"
+            var trivia = SyntaxFactory.ParseSyntaxTree(@"
                 /// <summary>This is the summary</summary>
                 /// <remarks>These are the remarks</remarks>
                 // This is another comment
-                ");
+                public int field;
+                ").GetRoot().GetLeadingTrivia();
 
             var actual = LeadingTriviaRewriter.WithoutDocumentationComments(trivia).ToFullString();
             var expected = @"
@@ -91,13 +93,14 @@ namespace Tests.PortToTripleSlash
         [Fact]
         public void WithoutDocumentationComments_RemovesMultiLineDocumentationComments()
         {
-            var trivia = SyntaxFactory.ParseLeadingTrivia(@"
+            var trivia = SyntaxFactory.ParseSyntaxTree(@"
                 /**
                  * <summary>This is the summary</summary>
                  * <remarks>These are the remarks</remarks>
                  * */
                 // This is another comment
-                ");
+                public int field;
+                ").GetRoot().GetLeadingTrivia();
 
             var actual = LeadingTriviaRewriter.WithoutDocumentationComments(trivia).ToFullString();
             var expected = @"

--- a/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
+++ b/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
@@ -49,17 +49,18 @@ namespace Tests.PortToTripleSlash
 
         public static IEnumerable<object[]> GetLeadingTriviaTests()
         {
-            yield return new object[] { LoadTestFiles("WhitespaceOnly") };
+            yield return new object[] { "WhitespaceOnly", LoadTestFiles("WhitespaceOnly") };
+            yield return new object[] { "Directives", LoadTestFiles("Directives") };
         }
 
-        private static IEnumerable<SyntaxTrivia> GetTestComments()
+        private static IEnumerable<SyntaxTrivia> GetTestComments(string testName)
         {
-            XmlTextSyntax summaryText = SyntaxFactory.XmlText();
+            XmlTextSyntax summaryText = SyntaxFactory.XmlText(testName);
             XmlElementSyntax summaryElement = SyntaxFactory.XmlSummaryElement(summaryText);
             DocumentationCommentTriviaSyntax summaryComment = SyntaxFactory.DocumentationComment(summaryElement);
             SyntaxTrivia summaryTrivia = SyntaxFactory.Trivia(summaryComment);
 
-            XmlTextSyntax remarksText = SyntaxFactory.XmlText();
+            XmlTextSyntax remarksText = SyntaxFactory.XmlText(testName);
             XmlElementSyntax remarksElement = SyntaxFactory.XmlRemarksElement(remarksText);
             DocumentationCommentTriviaSyntax remarksComment = SyntaxFactory.DocumentationComment(remarksElement);
             SyntaxTrivia remarksTrivia = SyntaxFactory.Trivia(remarksComment);
@@ -69,11 +70,11 @@ namespace Tests.PortToTripleSlash
 
         [Theory]
         [MemberData(nameof(GetLeadingTriviaTests))]
-        public void AddsXmlToClassDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        public void AddsXmlToClassDeclaration(string testName, (LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
         {
             var actual = LeadingTriviaRewriter.ApplyXmlComments(
                 test.Original.MyType,
-                GetTestComments()
+                GetTestComments(testName)
             ).GetLeadingTrivia().ToFullString();
 
             var expected = test.Expected.MyType.GetLeadingTrivia().ToFullString();
@@ -83,11 +84,11 @@ namespace Tests.PortToTripleSlash
 
         [Theory]
         [MemberData(nameof(GetLeadingTriviaTests))]
-        public void AddsXmlToEnumDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        public void AddsXmlToEnumDeclaration(string testName, (LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
         {
             var actual = LeadingTriviaRewriter.ApplyXmlComments(
                 test.Original.MyEnum,
-                GetTestComments()
+                GetTestComments(testName)
             ).GetLeadingTrivia().ToFullString();
 
             var expected = test.Expected.MyEnum.GetLeadingTrivia().ToFullString();
@@ -97,11 +98,11 @@ namespace Tests.PortToTripleSlash
 
         [Theory]
         [MemberData(nameof(GetLeadingTriviaTests))]
-        public void AddsXmlToFieldDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        public void AddsXmlToFieldDeclaration(string testName, (LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
         {
             var actual = LeadingTriviaRewriter.ApplyXmlComments(
                 test.Original.MyField,
-                GetTestComments()
+                GetTestComments(testName)
             ).GetLeadingTrivia().ToFullString();
 
             var expected = test.Expected.MyField.GetLeadingTrivia().ToFullString();
@@ -111,11 +112,11 @@ namespace Tests.PortToTripleSlash
 
         [Theory]
         [MemberData(nameof(GetLeadingTriviaTests))]
-        public void AddsXmlToPropertyDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        public void AddsXmlToPropertyDeclaration(string testName, (LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
         {
             var actual = LeadingTriviaRewriter.ApplyXmlComments(
                 test.Original.MyProperty,
-                GetTestComments()
+                GetTestComments(testName)
             ).GetLeadingTrivia().ToFullString();
 
             var expected = test.Expected.MyProperty.GetLeadingTrivia().ToFullString();
@@ -125,11 +126,11 @@ namespace Tests.PortToTripleSlash
 
         [Theory]
         [MemberData(nameof(GetLeadingTriviaTests))]
-        public void AddsXmlToMethodDeclaration((LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
+        public void AddsXmlToMethodDeclaration(string testName, (LeadingTriviaTestFile Original, LeadingTriviaTestFile Expected) test)
         {
             var actual = LeadingTriviaRewriter.ApplyXmlComments(
                 test.Original.MyMethod,
-                GetTestComments()
+                GetTestComments(testName)
             ).GetLeadingTrivia().ToFullString();
 
             var expected = test.Expected.MyMethod.GetLeadingTrivia().ToFullString();

--- a/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
+++ b/Tests/PortToTripleSlash/LeadingTriviaRewriterTests.cs
@@ -51,9 +51,9 @@ namespace Tests.PortToTripleSlash
 
         public static IEnumerable<object[]> GetLeadingTriviaTests()
         {
-            //yield return new object[] { "WhitespaceOnly", LoadTestFiles("WhitespaceOnly") };
-            //yield return new object[] { "Directives", LoadTestFiles("Directives") };
-            //yield return new object[] { "ExistingXml", LoadTestFiles("ExistingXml") };
+            yield return new object[] { "WhitespaceOnly", LoadTestFiles("WhitespaceOnly") };
+            yield return new object[] { "Directives", LoadTestFiles("Directives") };
+            yield return new object[] { "ExistingXml", LoadTestFiles("ExistingXml") };
             yield return new object[] { "DirectivesExistingXml", LoadTestFiles("DirectivesExistingXml") };
         }
 

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/Directives.Expected.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/Directives.Expected.cs
@@ -1,19 +1,19 @@
 ﻿namespace LeadingTriviaTestData.Directives.Expected
 {
-    /// <summary>Directives</summary>
-    /// <remarks>Directives</remarks>
 #if false
     internal
 #else
+    /// <summary>Directives</summary>
+    /// <remarks>Directives</remarks>
     public
 #endif
     class MyType
     {
         #region MyEnum
 
+#if true
         /// <summary>Directives</summary>
         /// <remarks>Directives</remarks>
-#if true
         public
 #else
         internal
@@ -30,6 +30,7 @@
 #pragma warning disable
         /// <summary>Directives</summary>
         /// <remarks>Directives</remarks>
+        // This comment should remain below the XML comments
         public int MyField;
 #pragma warning restore
 
@@ -49,9 +50,9 @@
         }
 #nullable restore
 
+#if true
         /// <summary>Directives</summary>
         /// <remarks>Directives</remarks>
-#if true
         public bool MyMethod()
         {
             return true;

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/Directives.Expected.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/Directives.Expected.cs
@@ -1,0 +1,61 @@
+﻿namespace LeadingTriviaTestData.Directives.Expected
+{
+    /// <summary>Directives</summary>
+    /// <remarks>Directives</remarks>
+#if false
+    internal
+#else
+    public
+#endif
+    class MyType
+    {
+        #region MyEnum
+
+        /// <summary>Directives</summary>
+        /// <remarks>Directives</remarks>
+#if true
+        public
+#else
+        internal
+#endif
+        enum MyEnum
+        {
+            FirstValue = 1,
+            SecondValue,
+            ThirdValue,
+        }
+
+        #endregion
+
+#pragma warning disable
+        /// <summary>Directives</summary>
+        /// <remarks>Directives</remarks>
+        public int MyField;
+#pragma warning restore
+
+#nullable enable
+        /// <summary>Directives</summary>
+        /// <remarks>Directives</remarks>
+        public string MyProperty
+        {
+            get
+            {
+                return "";
+            }
+            set
+            {
+
+            }
+        }
+#nullable restore
+
+        /// <summary>Directives</summary>
+        /// <remarks>Directives</remarks>
+#if true
+        public bool MyMethod()
+        {
+            return true;
+        }
+#endif
+    }
+}

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/Directives.Original.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/Directives.Original.cs
@@ -1,0 +1,51 @@
+﻿namespace LeadingTriviaTestData.Directives.Original
+{
+#if false
+    internal
+#else
+    public
+#endif
+    class MyType
+    {
+        #region MyEnum
+
+#if true
+        public
+#else
+        internal
+#endif
+        enum MyEnum
+        {
+            FirstValue = 1,
+            SecondValue,
+            ThirdValue,
+        }
+
+        #endregion
+
+#pragma warning disable
+        public int MyField;
+#pragma warning restore
+
+#nullable enable
+        public string MyProperty
+        {
+            get
+            {
+                return "";
+            }
+            set
+            {
+
+            }
+        }
+#nullable restore
+
+#if true
+        public bool MyMethod()
+        {
+            return true;
+        }
+#endif
+    }
+}

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/Directives.Original.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/Directives.Original.cs
@@ -24,6 +24,7 @@
         #endregion
 
 #pragma warning disable
+        // This comment should remain below the XML comments
         public int MyField;
 #pragma warning restore
 

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/DirectivesExistingXml.Expected.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/DirectivesExistingXml.Expected.cs
@@ -1,0 +1,62 @@
+﻿namespace LeadingTriviaTestData.DirectivesExistingXml.Expected
+{
+    /// <summary>DirectivesExistingXml</summary>
+    /// <remarks>DirectivesExistingXml</remarks>
+#if false
+    internal
+#else
+    public
+#endif
+    class MyType
+    {
+        #region MyEnum
+
+#if true
+        /// <summary>DirectivesExistingXml</summary>
+        /// <remarks>DirectivesExistingXml</remarks>
+        public
+#else
+        internal
+#endif
+        enum MyEnum
+        {
+            FirstValue = 1,
+            SecondValue,
+            ThirdValue,
+        }
+
+        #endregion
+
+#pragma warning disable
+        // This comment should remain above the XML comments
+        /// <summary>DirectivesExistingXml</summary>
+        /// <remarks>DirectivesExistingXml</remarks>
+        public int MyField;
+#pragma warning restore
+
+#nullable enable
+        /// <summary>DirectivesExistingXml</summary>
+        /// <remarks>DirectivesExistingXml</remarks>
+        public string MyProperty
+        {
+            get
+            {
+                return "";
+            }
+            set
+            {
+
+            }
+        }
+#nullable restore
+
+#if true
+        /// <summary>DirectivesExistingXml</summary>
+        /// <remarks>DirectivesExistingXml</remarks>
+        public bool MyMethod()
+        {
+            return true;
+        }
+#endif
+    }
+}

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/DirectivesExistingXml.Original.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/DirectivesExistingXml.Original.cs
@@ -1,0 +1,82 @@
+﻿namespace LeadingTriviaTestData.DirectivesExistingXml.Original
+{
+    /// <summary>
+    /// This is the original summary
+    /// </summary>
+    /// <remarks>
+    /// These are the existing remarks
+    /// </remarks>
+#if false
+    internal
+#else
+    public
+#endif
+    class MyType
+    {
+        #region MyEnum
+
+#if true
+        /// <summary>
+        /// This is the original summary
+        /// </summary>
+        /// <remarks>
+        /// These are the existing remarks
+        /// </remarks>
+        public
+#else
+        internal
+#endif
+        enum MyEnum
+        {
+            FirstValue = 1,
+            SecondValue,
+            ThirdValue,
+        }
+
+        #endregion
+
+#pragma warning disable
+        // This comment should remain above the XML comments
+        /// <summary>
+        /// This is the original summary
+        /// </summary>
+        /// <remarks>
+        /// These are the existing remarks
+        /// </remarks>
+        public int MyField;
+#pragma warning restore
+
+#nullable enable
+        /// <summary>
+        /// This is the original summary
+        /// </summary>
+        /// <remarks>
+        /// These are the existing remarks
+        /// </remarks>
+        public string MyProperty
+        {
+            get
+            {
+                return "";
+            }
+            set
+            {
+
+            }
+        }
+#nullable restore
+
+#if true
+        /// <summary>
+        /// This is the original summary
+        /// </summary>
+        /// <remarks>
+        /// These are the existing remarks
+        /// </remarks>
+        public bool MyMethod()
+        {
+            return true;
+        }
+#endif
+    }
+}

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/ExistingXml.Expected.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/ExistingXml.Expected.cs
@@ -1,0 +1,56 @@
+﻿namespace LeadingTriviaTestData.ExistingXml.Expected
+{
+    /// <summary>ExistingXml</summary>
+    /// <remarks>ExistingXml</remarks>
+    // Single line comment to keep, but it should remain below the XML comments
+    /* Multi-line comment to keep
+     * But it should remain below the XML comments */
+    public class MyType
+    {
+        /// <summary>ExistingXml</summary>
+        /// <remarks>ExistingXml</remarks>
+        // Single line comment to keep, but it should remain below the XML comments
+        /* Multi-line comment to keep
+         * But it should remain below the XML comments */
+        public enum MyEnum
+        {
+            FirstValue = 1,
+            SecondValue,
+            ThirdValue,
+        }
+
+        /// <summary>ExistingXml</summary>
+        /// <remarks>ExistingXml</remarks>
+        // Single line comment to keep, but it should remain below the XML comments
+        /* Multi-line comment to keep
+         * But it should remain below the XML comments */
+        public int MyField;
+
+        /// <summary>ExistingXml</summary>
+        /// <remarks>ExistingXml</remarks>
+        // Single line comment to keep, but it should remain below the XML comments
+        /* Multi-line comment to keep
+         * But it should remain below the XML comments */
+        public string MyProperty
+        {
+            get
+            {
+                return "";
+            }
+            set
+            {
+
+            }
+        }
+
+        /// <summary>ExistingXml</summary>
+        /// <remarks>ExistingXml</remarks>
+        // Single line comment to keep, but it should remain below the XML comments
+        /* Multi-line comment to keep
+         * But it should remain below the XML comments */
+        public bool MyMethod()
+        {
+            return true;
+        }
+    }
+}

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/ExistingXml.Expected.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/ExistingXml.Expected.cs
@@ -1,17 +1,17 @@
 ﻿namespace LeadingTriviaTestData.ExistingXml.Expected
 {
+    // Single line comment to keep above the XML comments
     /// <summary>ExistingXml</summary>
     /// <remarks>ExistingXml</remarks>
-    // Single line comment to keep, but it should remain below the XML comments
     /* Multi-line comment to keep
-     * But it should remain below the XML comments */
+     * below the XML comments */
     public class MyType
     {
+        // Single line comment to keep above the XML comments
         /// <summary>ExistingXml</summary>
         /// <remarks>ExistingXml</remarks>
-        // Single line comment to keep, but it should remain below the XML comments
         /* Multi-line comment to keep
-         * But it should remain below the XML comments */
+         * below the XML comments */
         public enum MyEnum
         {
             FirstValue = 1,
@@ -19,18 +19,18 @@
             ThirdValue,
         }
 
+        // Single line comment to keep above the XML comments
         /// <summary>ExistingXml</summary>
         /// <remarks>ExistingXml</remarks>
-        // Single line comment to keep, but it should remain below the XML comments
         /* Multi-line comment to keep
-         * But it should remain below the XML comments */
+         * below the XML comments */
         public int MyField;
 
+        // Single line comment to keep above the XML comments
         /// <summary>ExistingXml</summary>
         /// <remarks>ExistingXml</remarks>
-        // Single line comment to keep, but it should remain below the XML comments
         /* Multi-line comment to keep
-         * But it should remain below the XML comments */
+         * below the XML comments */
         public string MyProperty
         {
             get
@@ -43,11 +43,11 @@
             }
         }
 
+        // Single line comment to keep above the XML comments
         /// <summary>ExistingXml</summary>
         /// <remarks>ExistingXml</remarks>
-        // Single line comment to keep, but it should remain below the XML comments
         /* Multi-line comment to keep
-         * But it should remain below the XML comments */
+         * below the XML comments */
         public bool MyMethod()
         {
             return true;

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/ExistingXml.Original.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/ExistingXml.Original.cs
@@ -1,25 +1,25 @@
 ﻿namespace LeadingTriviaTestData.ExistingXml.Original
 {
+    // Single line comment to keep above the XML comments
     /// <summary>
     /// This was the original summary
     /// </summary>
     /// <remarks>
     /// These were the original remarks
     /// </remarks>
-    // Single line comment to keep, but it should remain below the XML comments
     /* Multi-line comment to keep
-     * But it should remain below the XML comments */
+     * below the XML comments */
     public class MyType
     {
+        // Single line comment to keep above the XML comments
         /// <summary>
         /// This was the original summary
         /// </summary>
         /// <remarks>
         /// These were the original remarks
         /// </remarks>
-        // Single line comment to keep, but it should remain below the XML comments
         /* Multi-line comment to keep
-         * But it should remain below the XML comments */
+         * below the XML comments */
         public enum MyEnum
         {
             FirstValue = 1,
@@ -27,28 +27,26 @@
             ThirdValue,
         }
 
+        // Single line comment to keep above the XML comments
         /// <summary>
         /// This was the original summary
         /// </summary>
         /// <remarks>
         /// These were the original remarks
         /// </remarks>
-        // Single line comment to keep, but it should remain below the XML comments
         /* Multi-line comment to keep
-         * But it should remain below the XML comments */
+         * below the XML comments */
         public int MyField;
 
-        /**
-         * <summary>
-         * This was the original summary
-         * </summary>
-         * <remarks>
-         * This were the original remarks
-         * </remarks>
-         */
-        // Single line comment to keep, but it should remain below the XML comments
+        // Single line comment to keep above the XML comments
+        /// <summary>
+        /// This was the original summary
+        /// </summary>
+        /// <remarks>
+        /// These were the original remarks
+        /// </remarks>
         /* Multi-line comment to keep
-         * But it should remain below the XML comments */
+         * below the XML comments */
         public string MyProperty
         {
             get
@@ -61,15 +59,15 @@
             }
         }
 
+        // Single line comment to keep above the XML comments
         /// <summary>
         /// This was the original summary
         /// </summary>
         /// <remarks>
         /// These were the original remarks
         /// </remarks>
-        // Single line comment to keep, but it should remain below the XML comments
         /* Multi-line comment to keep
-         * But it should remain below the XML comments */
+         * below the XML comments */
         public bool MyMethod()
         {
             return true;

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/ExistingXml.Original.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/ExistingXml.Original.cs
@@ -1,0 +1,78 @@
+﻿namespace LeadingTriviaTestData.ExistingXml.Original
+{
+    /// <summary>
+    /// This was the original summary
+    /// </summary>
+    /// <remarks>
+    /// These were the original remarks
+    /// </remarks>
+    // Single line comment to keep, but it should remain below the XML comments
+    /* Multi-line comment to keep
+     * But it should remain below the XML comments */
+    public class MyType
+    {
+        /// <summary>
+        /// This was the original summary
+        /// </summary>
+        /// <remarks>
+        /// These were the original remarks
+        /// </remarks>
+        // Single line comment to keep, but it should remain below the XML comments
+        /* Multi-line comment to keep
+         * But it should remain below the XML comments */
+        public enum MyEnum
+        {
+            FirstValue = 1,
+            SecondValue,
+            ThirdValue,
+        }
+
+        /// <summary>
+        /// This was the original summary
+        /// </summary>
+        /// <remarks>
+        /// These were the original remarks
+        /// </remarks>
+        // Single line comment to keep, but it should remain below the XML comments
+        /* Multi-line comment to keep
+         * But it should remain below the XML comments */
+        public int MyField;
+
+        /**
+         * <summary>
+         * This was the original summary
+         * </summary>
+         * <remarks>
+         * This were the original remarks
+         * </remarks>
+         */
+        // Single line comment to keep, but it should remain below the XML comments
+        /* Multi-line comment to keep
+         * But it should remain below the XML comments */
+        public string MyProperty
+        {
+            get
+            {
+                return "";
+            }
+            set
+            {
+
+            }
+        }
+
+        /// <summary>
+        /// This was the original summary
+        /// </summary>
+        /// <remarks>
+        /// These were the original remarks
+        /// </remarks>
+        // Single line comment to keep, but it should remain below the XML comments
+        /* Multi-line comment to keep
+         * But it should remain below the XML comments */
+        public bool MyMethod()
+        {
+            return true;
+        }
+    }
+}

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/WhitespaceOnly.Expected.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/WhitespaceOnly.Expected.cs
@@ -1,11 +1,11 @@
 ﻿namespace LeadingTriviaTestData.WhitespaceOnly.Expected
 {
-    /// <summary></summary>
-    /// <remarks></remarks>
+    /// <summary>WhitespaceOnly</summary>
+    /// <remarks>WhitespaceOnly</remarks>
     public class MyType
     {
-        /// <summary></summary>
-        /// <remarks></remarks>
+        /// <summary>WhitespaceOnly</summary>
+        /// <remarks>WhitespaceOnly</remarks>
         public enum MyEnum
         {
             FirstValue = 1,
@@ -13,12 +13,12 @@
             ThirdValue,
         }
 
-        /// <summary></summary>
-        /// <remarks></remarks>
+        /// <summary>WhitespaceOnly</summary>
+        /// <remarks>WhitespaceOnly</remarks>
         public int MyField;
 
-        /// <summary></summary>
-        /// <remarks></remarks>
+        /// <summary>WhitespaceOnly</summary>
+        /// <remarks>WhitespaceOnly</remarks>
         public string MyProperty
         {
             get
@@ -31,8 +31,8 @@
             }
         }
 
-        /// <summary></summary>
-        /// <remarks></remarks>
+        /// <summary>WhitespaceOnly</summary>
+        /// <remarks>WhitespaceOnly</remarks>
         public bool MyMethod()
         {
             return true;

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/WhitespaceOnly.Expected.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/WhitespaceOnly.Expected.cs
@@ -1,0 +1,41 @@
+﻿namespace LeadingTriviaTestData.WhitespaceOnly.Expected
+{
+    /// <summary></summary>
+    /// <remarks></remarks>
+    public class MyType
+    {
+        /// <summary></summary>
+        /// <remarks></remarks>
+        public enum MyEnum
+        {
+            FirstValue = 1,
+            SecondValue,
+            ThirdValue,
+        }
+
+        /// <summary></summary>
+        /// <remarks></remarks>
+        public int MyField;
+
+        /// <summary></summary>
+        /// <remarks></remarks>
+        public string MyProperty
+        {
+            get
+            {
+                return "";
+            }
+            set
+            {
+
+            }
+        }
+
+        /// <summary></summary>
+        /// <remarks></remarks>
+        public bool MyMethod()
+        {
+            return true;
+        }
+    }
+}

--- a/Tests/PortToTripleSlash/TestData/LeadingTrivia/WhitespaceOnly.Original.cs
+++ b/Tests/PortToTripleSlash/TestData/LeadingTrivia/WhitespaceOnly.Original.cs
@@ -1,0 +1,31 @@
+﻿namespace LeadingTriviaTestData.WhitespaceOnly.Original
+{
+    public class MyType
+    {
+        public enum MyEnum
+        {
+            FirstValue = 1,
+            SecondValue,
+            ThirdValue,
+        }
+
+        public int MyField;
+
+        public string MyProperty
+        {
+            get
+            {
+                return "";
+            }
+            set
+            {
+
+            }
+        }
+
+        public bool MyMethod()
+        {
+            return true;
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -12,7 +12,34 @@
     <Compile Remove="PortToTripleSlash\TestData\Generics\SourceOriginal.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceExpected.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\Directives.Expected.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\Directives.Original.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\ExistingXml.Expected.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\ExistingXml.Original.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\WhitespaceOnly.Expected.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\WhitespaceOnly.Original.cs" />
     <!--Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\*.cs" /-->
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="PortToTripleSlash\TestData\LeadingTrivia\Directives.Expected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PortToTripleSlash\TestData\LeadingTrivia\Directives.Original.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PortToTripleSlash\TestData\LeadingTrivia\ExistingXml.Expected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PortToTripleSlash\TestData\LeadingTrivia\ExistingXml.Original.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PortToTripleSlash\TestData\LeadingTrivia\WhitespaceOnly.Expected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PortToTripleSlash\TestData\LeadingTrivia\WhitespaceOnly.Original.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -20,7 +20,6 @@
     <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\ExistingXml.Original.cs" />
     <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\WhitespaceOnly.Expected.cs" />
     <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\WhitespaceOnly.Original.cs" />
-    <!--Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\*.cs" /-->
   </ItemGroup>
 
   <ItemGroup>
@@ -76,7 +75,6 @@
     <None Include="PortToTripleSlash\TestData\Basic\SourceExpected.cs" />
     <None Include="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
     <None Include="PortToTripleSlash\TestData\Basic\MyAssembly.csproj" />
-    <!--None Include="PortToTripleSlash\TestData\LeadingTrivia\*.cs" /-->
   </ItemGroup>
 
 </Project>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -14,6 +14,8 @@
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
     <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\Directives.Expected.cs" />
     <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\Directives.Original.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\DirectivesExistingXml.Expected.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\DirectivesExistingXml.Original.cs" />
     <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\ExistingXml.Expected.cs" />
     <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\ExistingXml.Original.cs" />
     <Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\WhitespaceOnly.Expected.cs" />
@@ -22,6 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="PortToTripleSlash\TestData\LeadingTrivia\DirectivesExistingXml.Expected.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="PortToTripleSlash\TestData\LeadingTrivia\DirectivesExistingXml.Original.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="PortToTripleSlash\TestData\LeadingTrivia\Directives.Expected.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -12,6 +12,7 @@
     <Compile Remove="PortToTripleSlash\TestData\Generics\SourceOriginal.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceExpected.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
+    <!--Compile Remove="PortToTripleSlash\TestData\LeadingTrivia\*.cs" /-->
   </ItemGroup>
 
   <ItemGroup>
@@ -40,6 +41,7 @@
     <None Include="PortToTripleSlash\TestData\Basic\SourceExpected.cs" />
     <None Include="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
     <None Include="PortToTripleSlash\TestData\Basic\MyAssembly.csproj" />
+    <!--None Include="PortToTripleSlash\TestData\LeadingTrivia\*.cs" /-->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a draft of a `LeadingTriviaRewriter` that can replace or insert XML doc comments while retaining other leading trivia (such as pragmas). If this approach seems viable, it could be integrated into the `TripleSlashSyntaxRewriter` to take over the responsibility of inserting the XML doc comments and it should resolve carlossanlop/DocsPortingTool#65 once integrated.

I used a different unit testing approach so that the tests could focus on just the leading trivia behavior without needing to set up API docs to feed into the tests. There's a combination of true unit tests as well as functional tests in place, with moderate coverage. I have not conducted any integration testing yet though.

Some notes on the behavior of this rewriter:

1. It attempts to work on entire lines at a time -- deleting existing lines of doc comments, and inserting full lines
2. It respects the positioning of existing XML doc comments, replacing them with the new comments, but retaining the position
    * This serves as an override of the logic that calculates the position
    * This would result in minimal change to existing code
3. There is a lot of logic around retaining the indentation the follows the XML doc comments, while aligning the doc comment indentation up with the API
    * The tests illustrate having pragmas that are aligned at the beginning of the line as well as pragmas that are indented
4. Ordering of existing single-line and multi-line comments (and other leading trivia) is fully retained
5. When inserting new XML doc comments, there is an array of the type of leading trivia to leave above the comments and another for what to leave below
    * I expect these arrays will be iterated on through integration testing with the dotnet/runtime repo
